### PR TITLE
Fix fMP4 buffer eviction logic not removing evicted fragments.

### DIFF
--- a/src/controller/stream-controller.js
+++ b/src/controller/stream-controller.js
@@ -992,6 +992,10 @@ class StreamController extends BaseStreamController {
         frag.addElementaryStream(ElementaryStreamTypes.VIDEO);
       }
 
+      if (data.hasAudio === true && data.hasVideo === true && data.type === 'audiovideo') {
+        frag.addElementaryStream(ElementaryStreamTypes.AUDIOVIDEO);
+      }
+
       logger.log(`Parsed ${data.type},PTS:[${data.startPTS.toFixed(3)},${data.endPTS.toFixed(3)}],DTS:[${data.startDTS.toFixed(3)}/${data.endDTS.toFixed(3)}],nb:${data.nb},dropped:${data.dropped || 0}`);
 
       // Detect gaps in a fragment  and try to fix it by finding a keyframe in the previous fragment (see _findFragments)

--- a/src/loader/fragment.ts
+++ b/src/loader/fragment.ts
@@ -5,6 +5,7 @@ import LevelKey from './level-key';
 import { PlaylistLevelType } from '../types/loader';
 
 export enum ElementaryStreamTypes {
+  AUDIOVIDEO = 'audiovideo',
   AUDIO = 'audio',
   VIDEO = 'video',
 }
@@ -16,6 +17,7 @@ export default class Fragment {
 
   // Holds the types of data this fragment supports
   private _elementaryStreams: Record<ElementaryStreamTypes, boolean> = {
+    [ElementaryStreamTypes.AUDIOVIDEO]: false,
     [ElementaryStreamTypes.AUDIO]: false,
     [ElementaryStreamTypes.VIDEO]: false
   };


### PR DESCRIPTION
## Description

fMP4 fragments evicted from the buffer can't be played back again. This PR adds a new elementary stream type "audiovideo" for fMP4.

## Testing

Manual test:
- [x] No regression on MPEG-TS playback
- [x] fMP4 playback issue fixed